### PR TITLE
Fixed fullscreen bug. Added platform exclusion support. Fixed warnings

### DIFF
--- a/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXActorBase.cpp
+++ b/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXActorBase.cpp
@@ -4,7 +4,7 @@
 #include "EyeXActorBase.h"
 #include "EyeXPlayerController.h" // for the EyeXPlayerController check
 
-AEyeXActorBase::AEyeXActorBase(const class FPostConstructInitializeProperties& PCIP)
+AEyeXActorBase::AEyeXActorBase(const class FObjectInitializer& PCIP)
 : Super(PCIP)
 {
 	AEyeXActorBase::StaticClass();

--- a/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXBlueprintLibrary.cpp
+++ b/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXBlueprintLibrary.cpp
@@ -5,7 +5,7 @@
 
 IEyeXPlugin* UEyeXBlueprintLibrary::EyeX;
 
-UEyeXBlueprintLibrary::UEyeXBlueprintLibrary(const class FPostConstructInitializeProperties& PCIP)
+UEyeXBlueprintLibrary::UEyeXBlueprintLibrary(const class FObjectInitializer& PCIP)
 : Super(PCIP)
 {
 }

--- a/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXDataStream.cpp
+++ b/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXDataStream.cpp
@@ -3,7 +3,11 @@
 #include "EyeXPluginPrivatePCH.h"
 #include "EyeXDataStream.h"
 
+#if !PLATFORM_PS4
 #pragma warning(disable: 4996) // suppress warning: Function call with parameters that may be unsafe
+#else
+#define _snprintf snprintf
+#endif
 
 
 void FEyeXDataStream::AddToSnapshot(TX_HANDLE Snapshot, bool MarkAsDeleted) const
@@ -162,11 +166,12 @@ void FEyeXFixationDataStream::AddBehavior(TX_HANDLE Interactor) const
 //  Implementation of FEyeXEyePositionDataStream
 // -------------------------------------------------------------------
 
-char *FEyeXEyePositionDataStream::Id = "ds_eyeposition";
+#define DEFAULT_EYEPOSITION_ID "ds_eyeposition"
+const char *FEyeXEyePositionDataStream::Id = DEFAULT_EYEPOSITION_ID;
 
 void FEyeXEyePositionDataStream::GetInteractorId(char *buffer)
 {
-	_snprintf(buffer, MAX_DATA_STREAM_INTERACTOR_ID_SIZE, Id);
+	_snprintf(buffer, MAX_DATA_STREAM_INTERACTOR_ID_SIZE, DEFAULT_EYEPOSITION_ID);
 }
 
 FEyeXEyePositionDataStream::FEyeXEyePositionDataStream(FEyeXClientLibraryLoader& EyeXClient) :

--- a/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXDataStream.h
+++ b/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXDataStream.h
@@ -139,6 +139,6 @@ protected:
 
 private:
 
-	static char *Id;
+	static const char *Id;
 	FEyeXEyePosition Data;
 };

--- a/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXPlayerController.cpp
+++ b/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXPlayerController.cpp
@@ -44,7 +44,7 @@ static void VisualizeHit(bool bVisualizeDetection, UWorld *World, const FHitResu
 #endif
 
 
-AEyeXPlayerController::AEyeXPlayerController(const FPostConstructInitializeProperties& PCIP)
+AEyeXPlayerController::AEyeXPlayerController(const FObjectInitializer& PCIP)
 : Super(PCIP)
 {
 	AEyeXPlayerController::StaticClass();

--- a/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXPlugin.cpp
+++ b/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXPlugin.cpp
@@ -155,9 +155,11 @@ FEyeXGazePoint FEyeXPlugin::GetGazePoint(EEyeXGazePointDataMode::Type Mode)
 
 	auto stream = GetOrCreateGazePointDataStream(Mode);
 	auto last = stream->Last();
-	if (last.bHasValue)
+	auto screenBounds = GetScreenBounds();
+
+	if (last.bHasValue && screenBounds.bHasValue)
 	{
-		auto viewportPoint = FEyeXUtils::VirtualDesktopPixelToViewportPixel(last.Value);
+		auto viewportPoint = FEyeXUtils::VirtualDesktopPixelToViewportPixel(last.Value, screenBounds.Value);
 		if (viewportPoint.bHasValue)
 		{
 			return FEyeXGazePoint(viewportPoint.Value, last.TimeStamp, true);
@@ -202,9 +204,11 @@ FEyeXFixationDataPoint FEyeXPlugin::GetOngoingFixation(EEyeXFixationDataMode::Ty
 
 FEyeXFixationDataPoint FEyeXPlugin::ConvertFixationPointToViewportPixels(FEyeXFixationDataPoint fixation)
 {
-	if (fixation.bHasValue)
+	auto screenBounds = GetScreenBounds();
+
+	if (fixation.bHasValue && screenBounds.bHasValue)
 	{
-		auto viewportPoint = FEyeXUtils::VirtualDesktopPixelToViewportPixel(fixation.GazePoint);
+		auto viewportPoint = FEyeXUtils::VirtualDesktopPixelToViewportPixel(fixation.GazePoint, screenBounds.Value);
 		if (viewportPoint.bHasValue)
 		{
 			return FEyeXFixationDataPoint(viewportPoint.Value, fixation.BeginTimeStamp, fixation.Duration, true);

--- a/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXPlugin.h
+++ b/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXPlugin.h
@@ -51,7 +51,7 @@ private:
 	void SendGlobalInteractorSnapshot(bool markAsDeleted = false);
 	void UpdateConnectionStateOnAllStateAccessors();
 
-	static FEyeXFixationDataPoint ConvertFixationPointToViewportPixels(FEyeXFixationDataPoint dataPointInVirtualDesktopPixels);
+	FEyeXFixationDataPoint ConvertFixationPointToViewportPixels(FEyeXFixationDataPoint dataPointInVirtualDesktopPixels);
 
 private:
 

--- a/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXStateAccessor.cpp
+++ b/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXStateAccessor.cpp
@@ -3,7 +3,9 @@
 #include "EyeXPluginPrivatePCH.h"
 #include "EyeXStateAccessor.h"
 
-
+#if PLATFORM_PS4
+template<>
+#endif
 void TEyeXStateAccessor<TX_SIZE2>::HandleStateChanged(TX_CONSTHANDLE AsyncData)
 {
 	FEyeXScopedHandle stateBag(EyeXClient);
@@ -14,6 +16,9 @@ void TEyeXStateAccessor<TX_SIZE2>::HandleStateChanged(TX_CONSTHANDLE AsyncData)
 	}
 }
 
+#if PLATFORM_PS4
+template<>
+#endif
 void TEyeXStateAccessor<TX_RECT>::HandleStateChanged(TX_CONSTHANDLE AsyncData)
 {
 	FEyeXScopedHandle stateBag(EyeXClient);
@@ -24,6 +29,9 @@ void TEyeXStateAccessor<TX_RECT>::HandleStateChanged(TX_CONSTHANDLE AsyncData)
 	}
 }
 
+#if PLATFORM_PS4
+template<>
+#endif
 void TEyeXStateAccessor<TX_INTEGER>::HandleStateChanged(TX_CONSTHANDLE AsyncData)
 {
 	FEyeXScopedHandle stateBag(EyeXClient);

--- a/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXUtils.cpp
+++ b/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXUtils.cpp
@@ -41,20 +41,29 @@ FVector FEyeXUtils::EyeX3DPointToUnrealWorld(FVector EyeX3DPoint)
 	return FVector(-0.1f * EyeX3DPoint.Z, 0.1f * EyeX3DPoint.X, 0.1f * EyeX3DPoint.Y);
 }
 
-TEyeXMaybeValue<FVector2D> FEyeXUtils::VirtualDesktopPixelToViewportPixel(FVector2D Point)
+TEyeXMaybeValue<FVector2D> FEyeXUtils::VirtualDesktopPixelToViewportPixel(FVector2D Point, FEyeXScreenBounds ScreenBounds)
 {
 	auto viewport = GetViewport();
 	if (viewport == nullptr)
 	{
 		return TEyeXMaybeValue<FVector2D>(FVector2D::ZeroVector, false);
 	}
+	
+	if (viewport->IsFullscreen())
+	{
+		auto viewportSize = viewport->GetSizeXY();
+		FVector2D viewportPixels((Point.X / ScreenBounds.Width) * viewportSize.X, (Point.Y / ScreenBounds.Height) * viewportSize.Y);
+		return TEyeXMaybeValue<FVector2D>(viewportPixels);
+	}
+	else
+	{
+		FIntPoint intPoint((int32)Point.X, (int32)Point.Y);
+		FVector2D viewportPoint = viewport->VirtualDesktopPixelToViewport(intPoint);
 
-	FIntPoint intPoint((int32)Point.X, (int32)Point.Y);
-	FVector2D viewportPoint = viewport->VirtualDesktopPixelToViewport(intPoint);
-
-	auto viewportSize = viewport->GetSizeXY();
-	FVector2D viewportPixels(viewportPoint.X * viewportSize.X, viewportPoint.Y * viewportSize.Y);
-	return TEyeXMaybeValue<FVector2D>(viewportPixels);
+		auto viewportSize = viewport->GetSizeXY();
+		FVector2D viewportPixels(viewportPoint.X * viewportSize.X, viewportPoint.Y * viewportSize.Y);
+		return TEyeXMaybeValue<FVector2D>(viewportPixels);
+	}
 }
 
 FVector FEyeXUtils::VirtualDesktopPixelToEyeX3DPoint(FVector2D VirtualDesktopPoint, FVector2D DisplaySizeMm, FEyeXScreenBounds ScreenBoundsPixels)

--- a/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXUtils.h
+++ b/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXUtils.h
@@ -11,7 +11,7 @@ public:
 	static FViewport *GetViewport();
 
 	static FVector EyeX3DPointToUnrealWorld(FVector EyeX3DPoint);
-	static TEyeXMaybeValue<FVector2D> VirtualDesktopPixelToViewportPixel(FVector2D Point);
+	static TEyeXMaybeValue<FVector2D> VirtualDesktopPixelToViewportPixel(FVector2D Point, FEyeXScreenBounds ScreenBounds);
 	static FVector VirtualDesktopPixelToEyeX3DPoint(FVector2D VirtualDesktopPoint, FVector2D DisplaySizeMm, FEyeXScreenBounds ScreenBoundsPixels);
 
 	static int32 ECCArrayToBitField(const TArray<TEnumAsByte<ECollisionChannel> >& ChannelList);

--- a/Plugins/TobiiEyeX/Source/TobiiEyeX/Public/EyeXTypes.h
+++ b/Plugins/TobiiEyeX/Source/TobiiEyeX/Public/EyeXTypes.h
@@ -238,9 +238,9 @@ struct TEyeXMaybeValue
 	/** Value, if bHasValue. Otherwise undefined. */
 	ValueType Value;
 
-	TEyeXMaybeValue<ValueType>::TEyeXMaybeValue(const ValueType& Value, bool bHasValue = true) :
-		Value(Value),
-		bHasValue(bHasValue)
+	TEyeXMaybeValue(const ValueType& Value, bool bHasValue = true) :
+		bHasValue(bHasValue),
+		Value(Value)
 	{}
 };
 


### PR DESCRIPTION
The ctors are using new objects, so getting warnings in 4.7.6.

There is a bug where the plugin cannot correctly identify a surface that differs from the screen resolution when in fullscreen mode 0. This fixes that.

Also tried to address using the plugin when building for several platforms.

The code runs in my projects, but should probably be Tobii QA tested before being integrated :)

Best regards,
/Temaran