### PR TITLE
Added an option for gaze point emulation via viewport center.

### DIFF
--- a/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXBlueprintLibrary.cpp
+++ b/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXBlueprintLibrary.cpp
@@ -107,6 +107,24 @@ void UEyeXBlueprintLibrary::SetEmulationMode(TEnumAsByte<EEyeXEmulationMode::Typ
 	}
 }
 
+TEnumAsByte<EEyeXEmulationPoint::Type> UEyeXBlueprintLibrary::GetEmulationPointType()
+{
+	if (IsEyeXModuleAvailable())
+	{
+		return EyeX->GetEmulationPointType();
+	}
+
+	return EEyeXEmulationPoint::MousePosition;
+}
+
+void UEyeXBlueprintLibrary::SetEmulationPointType(TEnumAsByte<EEyeXEmulationPoint::Type> PointType)
+{
+	if (IsEyeXModuleAvailable())
+	{
+		EyeX->SetEmulationPointType(PointType);
+	}
+}
+
 bool UEyeXBlueprintLibrary::IsEyeXModuleAvailable()
 {
 	static bool bIsModuleInitialized = false;

--- a/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXBlueprintLibrary.h
+++ b/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXBlueprintLibrary.h
@@ -160,6 +160,22 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "EyeX")
 	static void SetEmulationMode(TEnumAsByte<EEyeXEmulationMode::Type> Mode);
 
+	/**
+	 * Gets the current emulation point type. The default is mouse position.
+	 *
+	 * @return emulation point type.
+	 */
+	UFUNCTION(BlueprintPure, Category = "EyeX")
+	static TEnumAsByte<EEyeXEmulationPoint::Type> GetEmulationPointType();
+
+	/**
+	 * Sets the emulation point for the eye-gaze point. The default is mouse position.
+	 *
+	 * @param PointType - emulation point type.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "EyeX")
+	static void SetEmulationPointType(TEnumAsByte<EEyeXEmulationPoint::Type> PointType);
+
 private:
 
 	static bool IsEyeXModuleAvailable();

--- a/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXPlayerController.cpp
+++ b/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXPlayerController.cpp
@@ -105,12 +105,17 @@ void AEyeXPlayerController::Tick(float DeltaSeconds)
 		return;
 	}
 
-	if (MinUpdateDistance > 0 &&
-		LastUsedGazePoint.bHasValue &&
-		DistanceInMM(GazePoint.Value, LastUsedGazePoint.Value, 1 / GetApproximatePixelsPerMillimeter()) < MinUpdateDistance)
+	// If the emulation mode is enabled and the emulation point is the center of the viewport, don't perform minimum update distance check.
+	// This is because this check will always fail in this case since the emulated gaze point will always be the same.
+	if (!(EyeX->GetEmulationMode() == EEyeXEmulationMode::Enabled && EyeX->GetEmulationPointType() == EEyeXEmulationPoint::ViewportCenter))
 	{
-		// Too close to previous point: ignore.
-		return;
+		if (MinUpdateDistance > 0 &&
+			LastUsedGazePoint.bHasValue &&
+			DistanceInMM(GazePoint.Value, LastUsedGazePoint.Value, 1 / GetApproximatePixelsPerMillimeter()) < MinUpdateDistance)
+		{
+			// Too close to previous point: ignore.
+			return;
+		}
 	}
 
 	LastUsedGazePoint = GazePoint;

--- a/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXPlugin.cpp
+++ b/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXPlugin.cpp
@@ -31,6 +31,7 @@ void FEyeXPlugin::StartupModule()
 	Context = TX_EMPTY_HANDLE;
 	bIsConnected = false;
 	EmulationMode = EEyeXEmulationMode::Disabled;
+	EmulationPointType = EEyeXEmulationPoint::MousePosition;
 
 	ALL_STATE_ACCESSORS;
 	for (int i = 0; i < STATE_ACCESSOR_COUNT; i++)
@@ -148,9 +149,17 @@ FEyeXGazePoint FEyeXPlugin::GetGazePoint(EEyeXGazePointDataMode::Type Mode)
 			return FEyeXGazePoint::Invalid();
 		}
 
-		FVector2D mousePosition;
-		gameViewport->GetMousePosition(mousePosition);
-		return FEyeXGazePoint(mousePosition, 0, true);
+		FVector2D emulatedGazePoint;
+		if (EmulationPointType == EEyeXEmulationPoint::MousePosition)
+		{
+			gameViewport->GetMousePosition(emulatedGazePoint);
+		}
+		else if (EmulationPointType == EEyeXEmulationPoint::ViewportCenter)
+		{
+			gameViewport->GetViewportSize(emulatedGazePoint);
+			emulatedGazePoint /= 2;
+		}
+		return FEyeXGazePoint(emulatedGazePoint, 0, true);
 	}
 
 	auto stream = GetOrCreateGazePointDataStream(Mode);
@@ -338,6 +347,16 @@ EEyeXEmulationMode::Type FEyeXPlugin::GetEmulationMode()
 void FEyeXPlugin::SetEmulationMode(EEyeXEmulationMode::Type Mode)
 {
 	EmulationMode = Mode;
+}
+
+EEyeXEmulationPoint::Type FEyeXPlugin::GetEmulationPointType() const
+{
+	return EmulationPointType;
+}
+
+void FEyeXPlugin::SetEmulationPointType(EEyeXEmulationPoint::Type PointType)
+{
+	EmulationPointType = PointType;
 }
 
 void FEyeXPlugin::OnConnectionStateChanged(TX_CONNECTIONSTATE ConnectionState)

--- a/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXPlugin.h
+++ b/Plugins/TobiiEyeX/Source/TobiiEyeX/Private/EyeXPlugin.h
@@ -37,6 +37,8 @@ public:
 	virtual EEyeXUserPresence::Type GetUserPresence() override;
 	virtual EEyeXEmulationMode::Type GetEmulationMode() override;
 	virtual void SetEmulationMode(EEyeXEmulationMode::Type Mode) override;
+	virtual EEyeXEmulationPoint::Type GetEmulationPointType() const override;
+	virtual void SetEmulationPointType(EEyeXEmulationPoint::Type PointType) override;
 
 private:
 
@@ -65,4 +67,5 @@ private:
 	IEyeXStateAccessor *EyeTrackingDeviceStatusAccessor;
 	IEyeXStateAccessor *UserPresenceAccessor;
 	EEyeXEmulationMode::Type EmulationMode;
+	EEyeXEmulationPoint::Type EmulationPointType;
 };

--- a/Plugins/TobiiEyeX/Source/TobiiEyeX/Public/EyeXTypes.h
+++ b/Plugins/TobiiEyeX/Source/TobiiEyeX/Public/EyeXTypes.h
@@ -245,7 +245,7 @@ struct TEyeXMaybeValue
 };
 
 /**
-* Describes the available modes for mouse emulation of the gaze point.
+* Describes the available modes for emulation of the gaze point.
 */
 UENUM(BlueprintType)
 namespace EEyeXEmulationMode
@@ -254,6 +254,19 @@ namespace EEyeXEmulationMode
 	{
 		Disabled		UMETA(DisplayName = "Disabled"),
 		Enabled			UMETA(DisplayName = "Enabled")
+	};
+}
+
+/**
+ * Describes the available points for emulation of the gaze point.
+ */
+UENUM(BlueprintType)
+namespace EEyeXEmulationPoint
+{
+	enum Type
+	{
+		MousePosition			UMETA(DisplayName = "MousePosition"),
+		ViewportCenter		UMETA(DisplayName = "ViewportCenter")
 	};
 }
 

--- a/Plugins/TobiiEyeX/Source/TobiiEyeX/Public/IEyeXPlugin.h
+++ b/Plugins/TobiiEyeX/Source/TobiiEyeX/Public/IEyeXPlugin.h
@@ -151,4 +151,17 @@ public:
 	 */
 	virtual void SetEmulationMode(EEyeXEmulationMode::Type Mode) = 0;
 
+	/**
+	 * Gets the current emulation point type. The default is mouse position.
+	 *
+	 * @return emulation point type.
+	 */
+	virtual EEyeXEmulationPoint::Type GetEmulationPointType() const = 0;
+
+	/**
+	 * Sets the emulation point for the eye-gaze point. The default is mouse position.
+	 *
+	 * @param PointType - emulation point type.
+	 */
+	virtual void SetEmulationPointType(EEyeXEmulationPoint::Type PointType) = 0;
 };


### PR DESCRIPTION
Emulation of the gaze point via mouse position is not very helpful in 3D games which have a lot of camera movement. When moving the mouse around to rotate the camera, most of the time the mouse pointer is near the edges of the screen, which is not an ideal place for the gaze point emulation. Locking the mouse to the center of the viewport is super annoying, specially during the development of the game.

Thus, I added an enum named `EEyeXEmulationPoint` which allows the user to choose whether they want the mouse position for the gaze point or the center of the viewport. 
A simpler way to do the same thing would have been to add the `MousePosition` and `ViewportCenter` enums to the `EEyeXEmulationMode` itself. But that would have been an API breaking change (if I removed the `EEyeXEmulationMode::Enabled` enum).